### PR TITLE
link to docs broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ chemistry (mainly physical/inorganic/analytical chemistry). Currently it include
 Documentation
 -------------
 Auto-generated API documentation for the latest stable release is found here:
-`<https://bjodah.github.io/chempy/latest>`_
+`<http://pythonhosted.org/chempy>`_
 (and the development version for the current master branch is found here:
 `<http://hera.physchem.kth.se/~chempy/branches/master/html>`_).
 


### PR DESCRIPTION
I think it should redirect to the pythonhosted site (as in this commit), but I'm not 100% sure