### PR TITLE
Fix balance_stoichiometry (fix gh-55)

### DIFF
--- a/chempy/chemistry.py
+++ b/chempy/chemistry.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function)
 from collections import OrderedDict, defaultdict
 from functools import reduce
 from itertools import chain
-from operator import itemgetter, mul
+from operator import itemgetter, mul, add
 import math
 import sys
 
@@ -1164,8 +1164,8 @@ def balance_stoichiometry(reactants, products, substances=None,
         return substances[sk].composition.get(ck, 0) * (-1 if sk in reactants else 1)
 
     A = Matrix([[_get(sk, ck) for sk in subst_keys] for ck in cks])
-    nullsp, = A.nullspace()
-    if 0 in nullsp:
+    nullsp = reduce(add, A.nullspace())
+    if any(n <= 0 for n in nullsp):
         raise ValueError("Superfluous species given.")
     x = nullsp/reduce(gcd, nullsp.T)
 

--- a/chempy/tests/test_chemistry.py
+++ b/chempy/tests/test_chemistry.py
@@ -212,6 +212,26 @@ def test_Equilibrium__cancel():
 
 
 @requires('sympy')
+def test_balance_stoichiometry__simple():
+    r2, p2 = balance_stoichiometry({'Na2CO3'}, {'Na2O', 'CO2'})
+    assert r2 == {'Na2CO3': 1}
+    assert p2 == {'Na2O': 1, 'CO2': 1}
+
+
+@requires('sympy')
+def test_balance_stoichiometry__underdetermined():
+    with pytest.raises(ValueError):
+        balance_stoichiometry({'C2H6', 'O2'}, {'H2O', 'CO2', 'CO'}, underdetermined=False)
+    reac, prod = balance_stoichiometry({'C2H6', 'O2'}, {'H2O', 'CO2', 'CO'})
+
+
+@requires('sympy')
+def test_balance_stoichiometry__missing_product_atom():
+    with pytest.raises(ValueError):  # No Al on product side
+        balance_stoichiometry({'C7H5(NO2)3', 'Al', 'NH4NO3'}, {'CO', 'H2O', 'N2'})
+
+
+@requires('sympy')
 def test_balance_stoichiometry():
     # 4 NH4ClO4 -> 2 N2 + 4 HCl + 6H2O + 5O2
     # 4 Al + 3O2 -> 2Al2O3
@@ -222,18 +242,9 @@ def test_balance_stoichiometry():
     assert reac == {'NH4ClO4': 6, 'Al': 10}
     assert prod == {'Al2O3': 5, 'HCl': 6, 'H2O': 9, 'N2': 3}
 
-    with pytest.raises(ValueError):
-        reac, prod = balance_stoichiometry({'C7H5(NO2)3', 'Al', 'NH4NO3'}, {'CO', 'H2O', 'N2'})
-
-    r2, p2 = balance_stoichiometry({'Na2CO3'}, {'Na2O', 'CO2'})
-    assert r2 == {'Na2CO3': 1}
-    assert p2 == {'Na2O': 1, 'CO2': 1}
-
     r3, p3 = balance_stoichiometry({'C2H6', 'O2'}, {'H2O', 'CO2'})
     assert r3 == {'C2H6': 2, 'O2': 7}
     assert p3 == {'CO2': 4, 'H2O': 6}
-    with pytest.raises(ValueError):
-        reac, prod = balance_stoichiometry({'C2H6', 'O2'}, {'H2O', 'CO2', 'CO'})
 
     r4, p4 = balance_stoichiometry({'C7H5(NO2)3', 'NH4NO3'}, {'CO', 'H2O', 'N2'})
     assert r4 == {'C7H5(NO2)3': 2, 'NH4NO3': 7}

--- a/chempy/tests/test_chemistry.py
+++ b/chempy/tests/test_chemistry.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import (absolute_import, division, print_function)
 
-from operator import attrgetter
+from functools import reduce
+from operator import attrgetter, add
 
 import pytest
 
+from ..util.arithmeticdict import ArithmeticDict
 from ..util.testing import requires
 from ..util.parsing import parsing_library
 from ..units import default_units, units_library, to_unitless
@@ -236,3 +238,12 @@ def test_balance_stoichiometry():
     r4, p4 = balance_stoichiometry({'C7H5(NO2)3', 'NH4NO3'}, {'CO', 'H2O', 'N2'})
     assert r4 == {'C7H5(NO2)3': 2, 'NH4NO3': 7}
     assert p4 == {'CO': 14, 'H2O': 19, 'N2': 10}
+
+    a5, b5 = {"C3H5NO", "CH4", "NH3", "H2O"}, {"C2H6", "CH4O", "CH5N", "CH3N"}
+    formulas = list(set.union(a5, b5))
+    substances = dict(zip(formulas, map(Substance.from_formula, formulas)))
+    compositions = {k: ArithmeticDict(int, substances[k].composition) for k in formulas}
+    r5, p5 = balance_stoichiometry(a5, b5)
+    compo_reac = dict(reduce(add, [compositions[k]*v for k, v in r5.items()]))
+    compo_prod = dict(reduce(add, [compositions[k]*v for k, v in p5.items()]))
+    assert compo_reac == compo_prod


### PR DESCRIPTION
To address #55 
This could use more tests still.

```
>>> from chempy import balance_stoichiometry
>>> reac, prod = balance_stoichiometry( { "C3H5NO", "CH4", "NH3", "H2O", } , { "C2H6", "CH4O", "CH5N", "CH3N", }, underdetermined=1 )
>>> print(reac)
>>> print(prod)
{'NH3': 5, 'CH4': 15, 'H2O': 2, 'C3H5NO': 4}
{'CH4O': 6, 'C2H6': 6, 'CH3N': 3, 'CH5N': 6}
```
Not sure the format of the output is optimal, but it could be improved later:
```
>>> balance_stoichiometry({'C', 'O2'}, {'CO', 'CO2'})
({'O2': x1/2 + 2, 'C': x1 + 2}, {'CO2': 2, 'CO': x1})
```