### PR TITLE
Fix balance stoich regression gh158 (#159)

### DIFF
--- a/chempy/chemistry.py
+++ b/chempy/chemistry.py
@@ -1283,12 +1283,23 @@ def balance_stoichiometry(reactants, products, substances=None,
             if substances[rk].composition.get(ck, 0) != 0:
                 break
         else:
-            raise ValueError("Component '%s' not among reactants" % ck)
+            any_pos = any(substances[pk].composition.get(ck, 0) > 0 for pk in products)
+            any_neg = any(substances[pk].composition.get(ck, 0) < 0 for pk in products)
+            if any_pos and any_neg:
+                pass  # negative and positive parts among products, no worries
+            else:
+                raise ValueError("Component '%s' not among reactants" % ck)
+
         for pk in products:
             if substances[pk].composition.get(ck, 0) != 0:
                 break
         else:
-            raise ValueError("Component '%s' not among products" % ck)
+            any_pos = any(substances[pk].composition.get(ck, 0) > 0 for pk in reactants)
+            any_neg = any(substances[pk].composition.get(ck, 0) < 0 for pk in reactants)
+            if any_pos and any_neg:
+                pass  # negative and positive parts among reactants, no worries
+            else:
+                raise ValueError("Component '%s' not among products" % ck)
 
     A = MutableDenseMatrix([[_get(ck, sk) for sk in subst_keys] for ck in cks])
     symbs = list(reversed([next(parametric_symbols) for _ in range(len(subst_keys))]))

--- a/chempy/tests/test_chemistry.py
+++ b/chempy/tests/test_chemistry.py
@@ -312,6 +312,14 @@ def test_balance_stoichiometry():
     assert r6 == dict(CuSCN=4, KIO3=7, HCl=14)
     assert p6 == dict(CuSO4=4, KCl=7, HCN=4, ICl=7, H2O=5)
 
+    r7, p7 = balance_stoichiometry({'Zn+2', 'e-'}, {'Zn'})
+    assert r7 == {'Zn+2': 1, 'e-': 2}
+    assert p7 == {'Zn': 1}
+
+    r8, p8 = balance_stoichiometry({'Zn'}, {'Zn+2', 'e-'})
+    assert r8 == {'Zn': 1}
+    assert p8 == {'Zn+2': 1, 'e-': 2}
+
 
 @requires('sympy')
 def test_balance_stoichiometry__ordering():


### PR DESCRIPTION
* Add failing test

* Fix gh-158: balance_stoichiometry({'Zn'}, {'Zn+2', 'e-'})

As implemented currently "component 0" represents *net* charge, and can
hence be *negative*. (which would not have been the case if e.g. 0 had
been chosen to represent e.g. number of electrons).

We add a special check for a component only existing on one side: if it's
present with both positive and negative sign, then the equation can still
be balanced.