### PR TITLE
Turn off sending a progress report to the console.

### DIFF
--- a/chempy/chemistry.py
+++ b/chempy/chemistry.py
@@ -1149,7 +1149,7 @@ def _solve_balancing_ilp_pulp(A):
     prob += reduce(add, x)
     for expr in [pulp.lpSum([x[i]*e for i, e in enumerate(row)]) for row in A.tolist()]:
         prob += expr == 0
-    prob.solve()
+    prob.solve(pulp.PULP_CBC_CMD(msg=False))
     return [pulp.value(_) for _ in x]
 
 


### PR DESCRIPTION
Turn off sending a progress report to the console when using the function balance_stoichiometry() with underdetermined=None.  Consistency is improved; in my experience, no other successful operation in the chempy library dumps to the console. To learn why this came to be, see  https://github.com/bjodah/chempy/issues/170 and https://github.com/coin-or/pulp/issues/351.  Partial credit to Franco Pesch, https://github.com/pchtsp.