### PR TITLE
Convert from pytest-pep8 to pytest-flake8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ sundials-*.tar.gz
 .jupyter/*
 !.jupyter/jupyter_notebook_config.py
 tmp/
+.coverage
+htmlcov/

--- a/chempy/electrolytes.py
+++ b/chempy/electrolytes.py
@@ -188,57 +188,57 @@ def B(eps_r, T, rho, b0=1, constants=None, units=None, backend=None):
     return B
 
 
-def limiting_log_gamma(I, z, A, I0=1, backend=None):
+def limiting_log_gamma(IS, z, A, I0=1, backend=None):
     """ Debye-Hyckel limiting formula """
     be = get_backend(backend)
-    one = be.pi**0
-    return -A*z**2*(I/I0)**(one/2)
+    one = be.pi ** 0
+    return -A*z**2*(IS/I0)**(one/2)
 
 
-def extended_log_gamma(I, z, a, A, B, C=0, I0=1, backend=None):
+def extended_log_gamma(IS, z, a, A, B, C=0, I0=1, backend=None):
     """ Debye-Huckel extended formula """
     be = get_backend(backend)
-    one = be.pi**0
-    I_I0 = I/I0
-    sqrt_I_I0 = (I_I0)**(one/2)
+    one = be.pi ** 0
+    I_I0 = IS / I0
+    sqrt_I_I0 = (I_I0) ** (one / 2)
     return -A*z**2 * sqrt_I_I0/(1 + B*a*sqrt_I_I0) + C*I_I0
 
 
-def davies_log_gamma(I, z, A, C=-0.3, I0=1, backend=None):
+def davies_log_gamma(IS, z, A, C=-0.3, I0=1, backend=None):
     """ Davies formula """
     be = get_backend(backend)
     one = be.pi**0
-    I_I0 = I/I0
+    I_I0 = IS/I0
     sqrt_I_I0 = (I_I0)**(one/2)
     return -A * z**2 * (sqrt_I_I0/(1 + sqrt_I_I0) + C*I_I0)
 
 
-def limiting_activity_product(I, stoich, z, T, eps_r, rho, backend=None):
+def limiting_activity_product(IS, stoich, z, T, eps_r, rho, backend=None):
     """ Product of activity coefficients based on DH limiting law. """
     be = get_backend(backend)
     Aval = A(eps_r, T, rho)
     tot = 0
     for idx, nr in enumerate(stoich):
-        tot += nr*limiting_log_gamma(I, z[idx], Aval)
+        tot += nr*limiting_log_gamma(IS, z[idx], Aval)
     return be.exp(tot)
 
 
-def extended_activity_product(I, stoich, z, a, T, eps_r, rho, C=0, backend=None):
+def extended_activity_product(IS, stoich, z, a, T, eps_r, rho, C=0, backend=None):
     be = get_backend(backend)
     Aval = A(eps_r, T, rho)
     Bval = B(eps_r, T, rho)
     tot = 0
     for idx, nr in enumerate(stoich):
-        tot += nr*extended_log_gamma(I, z[idx], a[idx], Aval, Bval, C)
+        tot += nr*extended_log_gamma(IS, z[idx], a[idx], Aval, Bval, C)
     return be.exp(tot)
 
 
-def davies_activity_product(I, stoich, z, a, T, eps_r, rho, C=-0.3, backend=None):
+def davies_activity_product(IS, stoich, z, a, T, eps_r, rho, C=-0.3, backend=None):
     be = get_backend(backend)
     Aval = A(eps_r, T, rho)
     tot = 0
     for idx, nr in enumerate(stoich):
-        tot += nr*davies_log_gamma(I, z[idx], Aval, C)
+        tot += nr*davies_log_gamma(IS, z[idx], Aval, C)
     return be.exp(tot)
 
 
@@ -246,13 +246,13 @@ class LimitingDebyeHuckelActivityProduct(_ActivityProductBase):
 
     def __call__(self, c):
         z = self.args[0]
-        I = ionic_strength(c, z)
-        return limiting_activity_product(I, self.stoich, *self.args)
+        IS = ionic_strength(c, z)
+        return limiting_activity_product(IS, self.stoich, *self.args)
 
 
 class ExtendedDebyeHuckelActivityProduct(_ActivityProductBase):
 
     def __call__(self, c):
         z = self.args[0]
-        I = ionic_strength(c, z)
-        return extended_activity_product(I, self.stoich, *self.args)
+        IS = ionic_strength(c, z)
+        return extended_activity_product(IS, self.stoich, *self.args)

--- a/chempy/kinetics/_native.py
+++ b/chempy/kinetics/_native.py
@@ -162,5 +162,5 @@ def get_native(rsys, odesys, integrator, skip_keys=(0,), steady_state_root=False
 
     if 'p_includes' not in ns_extend:
         ns_extend['p_includes'] = set()
-    ns_extend['p_includes'] |= {"<type_traits>",  "<vector>"}
+    ns_extend['p_includes'] |= {"<type_traits>", "<vector>"}
     return native_sys[integrator].from_other(odesys, namespace_extend=ns_extend, **kw)

--- a/chempy/kinetics/integrated.py
+++ b/chempy/kinetics/integrated.py
@@ -38,6 +38,8 @@ def pseudo_irrev(t, kf, prod, major, minor, backend=None):
     """
     be = get_backend(backend)
     return prod + minor*(1 - be.exp(-major*kf*t))
+
+
 pseudo_irrev.name = 'Pseudo first order irreversible'
 
 
@@ -69,6 +71,8 @@ def pseudo_rev(t, kf, kb, prod, major, minor, backend=None):
         -kb*prod + kf*major*minor + (kb*prod - kf*major*minor) *
         be.exp(-t*(kb + kf*major))
     )/(kb + kf*major)
+
+
 pseudo_rev.name = 'Pseudo first order reversible'
 
 
@@ -95,6 +99,8 @@ def binary_irrev(t, kf, prod, major, minor, backend=None):
     be = get_backend(backend)
     return prod + major*(1 - be.exp(-kf*(major-minor)*t))/(
         major/minor - be.exp(-kf*t*(major-minor)))
+
+
 binary_irrev.name = 'Second order irreversible'
 
 
@@ -134,6 +140,7 @@ def binary_rev(t, kf, kb, prod, major, minor, backend=None):
     x7 = (x3 + x5)*be.exp(-t*x5)
     x8 = x3 - x5
     return (x4*x8 + x5*x8 + x7*(x2 + x6))/(2*kf*(x6 + x7))
+
 
 binary_rev.name = 'Second order reversible'
 

--- a/chempy/kinetics/tests/test_arrhenius.py
+++ b/chempy/kinetics/tests/test_arrhenius.py
@@ -16,6 +16,7 @@ from ..arrhenius import (
 def test_arrhenius_equation():
     assert abs(arrhenius_equation(3, 831.4472, 100) - 3/2.7182818) < 1e-7
 
+
 _A1, _Ea1, _T1, _k1 = 1e10, 42e3, 273.15, 1e10 * math.exp(-42e3/(8.3145*273.15))
 
 

--- a/chempy/printing/web.py
+++ b/chempy/printing/web.py
@@ -9,6 +9,7 @@ def _html_clsname(key):
         '(', 'leftparen').replace(
         ')', 'rightparen')
 
+
 _html_semicolon = '&#59; '
 
 

--- a/chempy/properties/water_density_tanaka_2001.py
+++ b/chempy/properties/water_density_tanaka_2001.py
@@ -79,6 +79,7 @@ def water_density(T=None, T0=None, units=None, a=None,
         warnings.warn("Temperature is outside range (0-40 degC)")
     return a[4]*(1-((t + a[0])**2*(t + a[1]))/(a[2]*(t + a[3])))
 
+
 # bibtex format (generated at doi2bib.org):
 reference = {
     'doi': '10.1088/0026-1394/38/4/3',

--- a/chempy/properties/water_diffusivity_holz_2000.py
+++ b/chempy/properties/water_diffusivity_holz_2000.py
@@ -73,6 +73,7 @@ def water_self_diffusion_coefficient(T=None, units=None, warn=True,
         warnings.warn("Temperature is outside range (0-100 degC)")
     return _D0*((T/_TS) - 1)**gamma
 
+
 # bibtex format (generated at doi2bib.org):
 reference = {
     'doi': '10.1039/b005319h',

--- a/chempy/tests/test_chemistry.py
+++ b/chempy/tests/test_chemistry.py
@@ -36,9 +36,9 @@ def test_Substance():
 
 
 def test_Substance__2():
-    H2O = Substance(name='H2O',  charge=0, latex_name=r'\mathrm{H_{2}O}',
+    H2O = Substance(name='H2O', charge=0, latex_name=r'\mathrm{H_{2}O}',
                     data={'pKa': 14})  # will_be_missing_in='0.8.0', use data=...
-    OH_m = Substance(name='OH-',  charge=-1, latex_name=r'\mathrm{OH^{-}}')
+    OH_m = Substance(name='OH-', charge=-1, latex_name=r'\mathrm{OH^{-}}')
     assert sorted([OH_m, H2O], key=attrgetter('name')) == [H2O, OH_m]
 
 
@@ -450,7 +450,7 @@ C + CO       -> C + CO + CO2  # suggested solution:      2 CO      -> C +      C
 C +      CO2 -> C + CO + CO2  # suggested solution:  C +      CO2 ->     2 CO
     CO + CO2 -> C + CO + CO2  # suggested solution:      2 CO      -> C +      CO2
 """
-    for prob, sol in [l.split('#') for l in cases.strip().splitlines()]:
+    for prob, sol in [line.split('#') for line in cases.strip().splitlines()]:
         tst_r = Reaction.from_string(prob)
         ref_r = Reaction.from_string(sol.split(':')[1])
         tst_bal = balance_stoichiometry(tst_r.reac, tst_r.prod,
@@ -458,8 +458,8 @@ C +      CO2 -> C + CO + CO2  # suggested solution:  C +      CO2 ->     2 CO
         assert Reaction(*tst_bal) == ref_r
 
     with pytest.raises(ValueError):
-            balance_stoichiometry({'C', 'CO', 'CO2'}, {'C', 'CO', 'CO2'},
-                                  allow_duplicates=True, underdetermined=None)
+        balance_stoichiometry({'C', 'CO', 'CO2'}, {'C', 'CO', 'CO2'},
+                              allow_duplicates=True, underdetermined=None)
 
     gh120 = {'H4P2O7', 'HPO3', 'H2O'}, {'H4P2O7', 'HPO3'}
     bal120 = balance_stoichiometry(*gh120, allow_duplicates=True, underdetermined=None)

--- a/chempy/units.py
+++ b/chempy/units.py
@@ -47,13 +47,13 @@ else:
 
     default_units = NameSpace(pq)
     default_units.dm = default_units.decimetre = pq.UnitQuantity(
-        'decimetre',  default_units.m / 10.0, u_symbol='dm')
+        'decimetre', default_units.m / 10.0, u_symbol='dm')
     default_units.m3 = default_units.metre**3
     default_units.dm3 = default_units.decimetre**3
     default_units.cm3 = default_units.centimetre**3
     if not hasattr(default_units, 'molar'):
         default_units.molar = pq.UnitQuantity(
-            'M',  1e3 * default_units.mole/default_units.m3,
+            'M', 1e3 * default_units.mole/default_units.m3,
             u_symbol='M')
     if not hasattr(default_units, 'millimolar'):
         default_units.millimolar = pq.UnitQuantity(
@@ -61,7 +61,7 @@ else:
             u_symbol='mM')
     if not hasattr(default_units, 'micromolar'):
         default_units.micromolar = pq.UnitQuantity(
-            'uM',  1e-3 * default_units.mole/default_units.m3,
+            'uM', 1e-3 * default_units.mole/default_units.m3,
             u_symbol='μM')
     if not hasattr(default_units, 'nanomolar'):
         default_units.nanomolar = pq.UnitQuantity(
@@ -69,7 +69,7 @@ else:
             u_symbol='nM')
     if not hasattr(default_units, 'molal'):
         default_units.molal = pq.UnitQuantity(
-            'molal',  default_units.mole / default_units.kg,
+            'molal', default_units.mole / default_units.kg,
             u_symbol='molal')
     if not hasattr(default_units, 'per100eV'):
         default_units.per100eV = pq.UnitQuantity(
@@ -78,16 +78,16 @@ else:
             u_symbol='(100eV)**-1')
     if not hasattr(default_units, 'micromole'):
         default_units.micromole = pq.UnitQuantity(
-            'micromole',  pq.mole/1e6,  u_symbol=u'μmol')
+            'micromole', pq.mole/1e6, u_symbol=u'μmol')
     if not hasattr(default_units, 'nanomole'):
         default_units.nanomole = pq.UnitQuantity(
-            'nanomole',  pq.mole/1e9,  u_symbol=u'nmol')
+            'nanomole', pq.mole/1e9, u_symbol=u'nmol')
     if not hasattr(default_units, 'kilojoule'):
         default_units.kilojoule = pq.UnitQuantity(
-            'kilojoule',  1e3*pq.joule,  u_symbol='kJ')
+            'kilojoule', 1e3*pq.joule, u_symbol='kJ')
     if not hasattr(default_units, 'kilogray'):
         default_units.kilogray = pq.UnitQuantity(
-            'kilogray',  1e3*pq.gray,  u_symbol='kGy')
+            'kilogray', 1e3*pq.gray, u_symbol='kGy')
     if not hasattr(default_units, 'perMolar_perSecond'):
         default_units.perMolar_perSecond = 1/default_units.molar/pq.s
     if not hasattr(default_units, 'umol'):
@@ -134,6 +134,7 @@ def is_quantity(arg):
         return True  # this checks works even if quantities is not installed.
     else:
         return False
+
 
 # SI Base Quantities:
 time = ArithmeticDict(int, {'time': 1})
@@ -718,6 +719,7 @@ def _wrap_numpy(k):
     def f(*args, **kwargs):
         return numpy_func(*map(to_unitless, args), **kwargs)
     return f
+
 
 if np is None:
     patched_numpy = None

--- a/chempy/util/_dimensionality.py
+++ b/chempy/util/_dimensionality.py
@@ -21,4 +21,5 @@ class DimensionalitySI(defaultnamedtuple('DimensionalitySIBase', dimension_codes
     def __pow__(self, exp):
         return self.__class__(*(x*exp for x in self))
 
+
 base_registry = {name: DimensionalitySI(**{name: 1}) for name in dimension_codes}

--- a/chempy/util/parsing.py
+++ b/chempy/util/parsing.py
@@ -208,6 +208,7 @@ def _parse_stoich(stoich):
     return {symbols.index(k)+1: n for k, n
             in _get_formula_parser().parseString(stoich)}
 
+
 _greek_letters = (
     'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta',
     'iota', 'kappa', 'lambda', 'mu', 'nu', 'xi', 'omicron', 'pi', 'rho',

--- a/chempy/util/periodic.py
+++ b/chempy/util/periodic.py
@@ -56,6 +56,7 @@ def atomic_number(name):
     except ValueError:
         return lower_names.index(name.lower()) + 1
 
+
 # The data in '_relative_atomic_masses' is licensed under the CC-SA license
 # https://en.wikipedia.org/w/index.php?title=List_of_elements&oldid=700476748
 _relative_atomic_masses = (
@@ -87,6 +88,7 @@ def _get_relative_atomic_masses():
             yield float(mass.split('(')[0])
         else:
             yield(float(mass))
+
 
 relative_atomic_masses = tuple(_get_relative_atomic_masses())
 

--- a/chempy/util/pyutil.py
+++ b/chempy/util/pyutil.py
@@ -38,6 +38,7 @@ def deprecated(*args, **kwargs):
         *args, issues_url=lambda s: __url__ + '/issues/' +
         s.lstrip('gh-'), warning=ChemPyDeprecationWarning, **kwargs)
 
+
 warnings.simplefilter(os.environ.get('CHEMPY_DEPRECATION_FILTER', 'once'),
                       ChemPyDeprecationWarning)
 

--- a/chempy/util/rendering.py
+++ b/chempy/util/rendering.py
@@ -23,4 +23,5 @@ class TemplateEvaluator:
             template = template.replace(self.fmt % item, str(ev))
         return template
 
+
 eval_template = TemplateEvaluator(post_procs=(fold_constants, lambda x: str(x).replace(' ', '*')))

--- a/chempy/util/tests/test_stoich.py
+++ b/chempy/util/tests/test_stoich.py
@@ -16,14 +16,14 @@ from ..testing import requires
 @requires('numpy')
 def test_get_coeff_mtx():
     r = [
-        ({'A': 1},       {'B': 1}),
+        ({'A': 1}, {'B': 1}),
         ({'A': 1, 'B': 1}, {'C': 2})
     ]
     A = get_coeff_mtx('ABC', r)
     Aref = np.array([
         [-1, -1],
         [1, -1],
-        [0,  2]
+        [0, 2]
     ])
     assert np.allclose(A, Aref)
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+# Lint-only option from https://stackoverflow.com/a/60045845/12968623.
+def pytest_collection_modifyitems(session, config, items):
+    if config.getoption("--lint-only"):
+        lint_items = []
+        for linter in ["flake8"]:
+            if config.getoption(f"--{linter}"):
+                lint_items.extend(
+                    [item for item in items if item.get_closest_marker(linter)]
+                )
+        items[:] = lint_items
+
+
+def pytest_addoption(parser):
+    parser.addoption("--lint-only",
+                     action="store_true",
+                     default=False,
+                     help="Run linting checks only.")

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,6 +3,6 @@
 #   $ ./scripts/run_tests.sh
 # or
 #   $ ./scripts/run_tests.sh --cov chempy --cov-report html
-CHEMPY_DEPRECATION_FILTER='ignore' ${PYTHON:-python3} -m pytest -ra --doctest-modules --flakes $@
+CHEMPY_DEPRECATION_FILTER='ignore' ${PYTHON:-python3} -m pytest -ra --doctest-modules --flake8 $@
 MPLBACKEND=Agg ${PYTHON:-python3} -m doctest README.rst
 rstcheck README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,27 @@
 [tool:pytest]
-testpaths = chempy
-# pep8maxlinelength=119
-# pep8ignore =
-#     doc/conf.py ALL  # conf.py is a generated file
-#     test_water_viscosity_korson_1969.py E222  # multiple spaces after operator
-#     chempy/kinetics/tests/test_rates.py E221 E222 E226 E251
-flakes-ignore =
+norecursedirs = .* _* build dist conda-recipe scripts benchmarks doc deploy venv *cache*
+
+flake8-max-line-length = 119
+
+flake8-ignore =
+    # E221:  Multiple spaces before operator.
+    # E222:  Multiple spaces after operator.
+    # E226:  Missing space around arithmetic operator.
+    # E251:  unexpected spaces around keyword/parameter equals
+    # F401:  Multiple imports on one line.
+    # F403:  Module import not at top of file.
+    # W503:  Break before binary operator; warn on breaking after.
+    # W504:  Break after binary operator; warn on breaking before.
+    * W503 W504
+    __init__.py F401 F403
+    arrhenius.py F401
+    chempy/*.* E226
+    chempy/kinetics/tests/test_rates.py E221 E222 E251
+    chempy/properties/** E222
+    debye_huckel.py F401
     doc/conf.py ALL  # conf.py is a generated file
-    __init__.py UnusedImport ImportStarUsed
-    debye_huckel.py UnusedImport
-    eyring.py UnusedImport
-    arrhenius.py UnusedImport
-    * IsLiteral
+    eyring.py F401
+
 filterwarnings =
     ignore::chempy.ChemPyDeprecationWarning
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ RELEASE_VERSION = os.environ.get('%s_RELEASE_VERSION' % pkg_name.upper(), '')  #
 def _path_under_setup(*args):
     return os.path.join(os.path.dirname(__file__), *args)
 
+
 release_py_path = _path_under_setup(pkg_name, '_release.py')
 
 if len(RELEASE_VERSION) > 0:
@@ -92,7 +93,7 @@ extras_req = {
     'native': ['pycompilation>=0.4.12', 'pycodeexport>=0.1.3', 'appdirs'],
     'docs': ['Sphinx', 'sphinx_rtd_theme', 'numpydoc'],
     'plotting': ['bokeh>=0.13.0', 'ipywidgets'],
-    'testing': ['pytest>=3.9', 'pytest-cov', 'pytest-flakes', 'rstcheck']
+    'testing': ['pytest>=3.9', 'pytest-cov', 'pytest-flake8', 'rstcheck']
 }
 extras_req['all'] = list(chain(extras_req.values()))
 
@@ -125,10 +126,10 @@ if __name__ == '__main__':
             # Same commit should generate different sdist
             # depending on tagged version (set CHEMPY_RELEASE_VERSION)
             # this will ensure source distributions contain the correct version
-            shutil.move(release_py_path, release_py_path+'__temp__')
+            shutil.move(release_py_path, release_py_path + '__temp__')
             open(release_py_path, 'wt').write(
                 "__version__ = '{}'\n".format(__version__))
         setup(**setup_kwargs)
     finally:
         if TAGGED_RELEASE:
-            shutil.move(release_py_path+'__temp__', release_py_path)
+            shutil.move(release_py_path + '__temp__', release_py_path)


### PR DESCRIPTION
This converts from using pytest-pep8 to pytest-flake8 and adds a `--lint-only` option for linting without running other tests.