### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,7 +13,7 @@ jobs:
                          isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B102,B110,B112,B307,B404,B603,B607 .
       - run: black --check . || true
-      - run: codespell --ignore-words-list="ans,nam,nd,serie,te" || true  # --skip="*.css,*.js,*.lock"
+      - run: codespell --ignore-words-list="ans,claus,fith,nam,nd,ond,serie,te"
       - run: flake8 . --count --max-complexity=66 --max-line-length=118
                       --show-source --statistics
       - run: pip install flake8-bugbear flake8-comprehensions flake8-return flake8-simplify

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,7 +92,7 @@ v0.6.7
 v0.6.6
 ======
 - Support for containers in ``chempy.units.unit_of``.
-- ``balance_stoichiometry`` now correctly find the canoncial solution when ``underdetermined=None`` is passed.
+- ``balance_stoichiometry`` now correctly find the canonical solution when ``underdetermined=None`` is passed.
 - ``chempy.kinetics.integrated`` was refactored to have more approachable API.
 
 v0.6.5
@@ -114,7 +114,7 @@ v0.6.2
 
 v0.6.1
 ======
-- Extensive test suite in conda pacakge no longer require graphviz & latex
+- Extensive test suite in conda package no longer require graphviz & latex
 
 v0.6.0
 ======
@@ -122,7 +122,7 @@ v0.6.0
 - ``NameSpace`` and ``AttributeContainer`` are now public in ``.util.pyutil``.
 - New printers in ``chempy.printing``, allows user to subclass printers.
 - Jupyter Notebook representation of ``ReactionSystem`` is now interactive (JavaScript/CSS)
-- More data from the litterature: water viscosity (``chempy.properties.water_viscosity_korson_1969``).
+- More data from the literature: water viscosity (``chempy.properties.water_viscosity_korson_1969``).
 - New methods for ``ReactionSystem``:
   - ``split``: splits reaction-system into disjoint parts
   - ``categorize_substances``: e.g. "nonparticipating", "unaffected".
@@ -170,7 +170,7 @@ v0.5.0
 ======
 - ``.electrochemistry.nernst_formula`` - thanks to Adel Qalieh (@adelq)
 - moved ``.util.parsing.number_to_scientific_*`` to ``.printing(.numbers)``
-- Number formating now handles uncertainties.
+- Number formatting now handles uncertainties.
 - ``refereence`` in reimplementations now a dict
 - Fixes to ``.kinetics.ode.get_odesys`` (refactored)
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,5 +25,5 @@ This project uses `black <https://github.com/psf/black>`_ to format its source c
 ensures that style is consistent and alleviates some of the work associated with code review.
 
 If you want to contribute a major feature you may want to discuss this first by opening
-an issue (in order to avoid unneccessary work in case someone else is already working on
+an issue (in order to avoid unnecessary work in case someone else is already working on
 something related).

--- a/chempy/_util.py
+++ b/chempy/_util.py
@@ -57,7 +57,7 @@ def get_backend(backend):
 
 
 def intdiv(p, q):
-    """Integer divsions which rounds toward zero
+    """Integer divisions which rounds toward zero
 
     Examples
     --------

--- a/chempy/_util.py
+++ b/chempy/_util.py
@@ -57,7 +57,7 @@ def get_backend(backend):
 
 
 def intdiv(p, q):
-    """Integer divisions which rounds toward zero
+    """Integer division which rounds toward zero
 
     Examples
     --------

--- a/chempy/chemistry.py
+++ b/chempy/chemistry.py
@@ -205,7 +205,7 @@ class Substance(object):
 
     @staticmethod
     def composition_keys(substance_iter, skip_keys=()):
-        """Occuring :attr:`composition` keys among a series of substances"""
+        """Occurring :attr:`composition` keys among a series of substances"""
         keys = set()
         for s in substance_iter:
             if s.composition is None:
@@ -263,7 +263,7 @@ class Species(Substance):
             and if suffixes is missing in phases phase_idx is taken to be 0
         default_phase_idx: int or None (default: 0)
             If ``default_phase_idx`` is ``None``, ``ValueError`` is raised for
-                unkown suffixes.
+                unknown suffixes.
             Else ``default_phase_idx`` is used as ``phase_idx`` in those cases.
         \\*\\*kwargs:
             Keyword arguments passed on.
@@ -568,7 +568,7 @@ class Reaction(object):
         return True
 
     def check_all_integral(self, throw=False):
-        """Checks if all stoichiometric coefficents are integers"""
+        """Checks if all stoichiometric coefficients are integers"""
         for nam, cont in [
             (nam, getattr(self, nam))
             for nam in "reac prod inact_reac inact_prod".split()
@@ -1188,7 +1188,7 @@ class Equilibrium(Reaction):
             flip = True
         else:
             flip = False
-        other = int(other)  # convert SymPy "Integer" to Pyton "int"
+        other = int(other)  # convert SymPy "Integer" to Python "int"
         reac = dict(other * ArithmeticDict(int, self.reac))
         prod = dict(other * ArithmeticDict(int, self.prod))
         inact_reac = dict(other * ArithmeticDict(int, self.inact_reac))
@@ -1337,7 +1337,7 @@ def balance_stoichiometry(
         e.g. "C + O2 -> CO + CO2". Set to ``None`` if you want the symbols replaced
         so that the coefficients are the smallest possible positive (non-zero) integers.
     allow_duplicates : bool
-        If False: raises an excpetion if keys appear in both ``reactants`` and ``products``.
+        If False: raises an exception if keys appear in both ``reactants`` and ``products``.
 
     Examples
     --------
@@ -1557,7 +1557,7 @@ def balance_stoichiometry(
         if int(__version__.split(".")[1]) > 6:
             warnings.warn(  # deprecated because comparison with ``1`` problematic (True==1)
                 (
-                    "Pass underdetermined == None instead of ``1`` (depreacted since 0.7.0,"
+                    "Pass underdetermined == None instead of ``1`` (deprecated since 0.7.0,"
                     " will_be_missing_in='0.9.0')"
                 ),
                 ChemPyDeprecationWarning,

--- a/chempy/electrolytes.py
+++ b/chempy/electrolytes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This modules collects expressions related to ionic strenght, e.g. the Debye-Hückel expressions.
+This modules collects expressions related to ionic strength, e.g. the Debye-Hückel expressions.
 """
 
 from collections import OrderedDict

--- a/chempy/equilibria.py
+++ b/chempy/equilibria.py
@@ -381,7 +381,7 @@ class EqSystem(ReactionSystem):
         neqsys_type : str
             what method to use for NeqSys construction (get_neqsys_*)
         \\*\\*kwargs :
-            Keyword argumetns passed on to py:meth:`pyneqsys.NeqSys.solve_series`.
+            Keyword arguments passed on to py:meth:`pyneqsys.NeqSys.solve_series`.
 
         """
         _plot = plot_kwargs is not None

--- a/chempy/kinetics/ode.py
+++ b/chempy/kinetics/ode.py
@@ -153,7 +153,7 @@ def get_odesys(
         e.g. ``chempy.units.default_constants``, parameter keys not found in
         substitutions will be looked for as an attribute of ``constants`` when provided.
     \\*\\*kwargs :
-        Keyword arguemnts passed on to `SymbolicSys`.
+        Keyword arguments passed on to `SymbolicSys`.
 
     Returns
     -------

--- a/chempy/printing/js.py
+++ b/chempy/printing/js.py
@@ -83,7 +83,7 @@ def _js_rsys(cls_names_substances, substance_row_cls_irrel, rsys_id):
 
 
 class JSPrinter(CSSPrinter):
-    """Prints javascript-enabled HTML representaions"""
+    """Prints javascript-enabled HTML representations"""
 
     def _print_ReactionSystem(self, rsys, **kwargs):
         tab = super(JSPrinter, self)._print_ReactionSystem(rsys, **kwargs)

--- a/chempy/properties/__init__.py
+++ b/chempy/properties/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 """
 This package implements various parameterisations of properties from the
-litterature with relevance in chemistry.
+literature with relevance in chemistry.
 """

--- a/chempy/properties/sulfuric_acid_density_myhre_1998.py
+++ b/chempy/properties/sulfuric_acid_density_myhre_1998.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This module implements the denisty parameterisation of aqueous sulfuric acid
+This module implements the density parameterisation of aqueous sulfuric acid
 of Myhre et al. from 1998.
 """
 
@@ -136,7 +136,7 @@ def density_from_concentration(
         Convergence criterion for fixed-point iteration
         (default: 1e-3 kg/m³).
     maxiter : int
-        Maximum number of iterations (when exceeded a NoConvergence excpetion
+        Maximum number of iterations (when exceeded a NoConvergence exception
         is raised).
     \\*\\*kwargs:
         Keyword arguments passed onto ``rho_cb``.

--- a/chempy/properties/water_density_tanaka_2001.py
+++ b/chempy/properties/water_density_tanaka_2001.py
@@ -47,7 +47,7 @@ def water_density(T=None, T0=None, units=None, a=None, just_return_a=False, warn
     References
     ----------
     TANAKA M., GIRARD G., DAVIS R., PEUTO A. and BIGNELL N.,
-        "Recommanded table for the density of water between 0 °C and 40 °C
+        "Recommended table for the density of water between 0 °C and 40 °C
         based on recent experimental reports",
         Metrologia, 2001, 38, 301-309.
         http://iopscience.iop.org/article/10.1088/0026-1394/38/4/3

--- a/chempy/properties/water_diffusivity_holz_2000.py
+++ b/chempy/properties/water_diffusivity_holz_2000.py
@@ -39,9 +39,9 @@ def water_self_diffusion_coefficient(T=None, units=None, warn=True, err_mult=Non
     warn : bool (default: True)
         Emit UserWarning when outside temperature range.
     err_mult : length 2 array_like (default: None)
-        Perturb paramaters D0 and TS with err_mult[0]*dD0 and
+        Perturb parameters D0 and TS with err_mult[0]*dD0 and
         err_mult[1]*dTS respectively, where dD0 and dTS are the
-        reported uncertainties in the fitted paramters. Useful
+        reported uncertainties in the fitted parameters. Useful
         for estimating error in diffusion coefficient.
 
     References

--- a/chempy/reactionsystem.py
+++ b/chempy/reactionsystem.py
@@ -468,7 +468,7 @@ class ReactionSystem(object):
 
         Returns
         -------
-        pair of ReactionSystem instaces: the "sum" and "duplicates"
+        pair of ReactionSystem instances: the "sum" and "duplicates"
 
         """
         iter_rs = iter(rsystems)
@@ -583,7 +583,7 @@ class ReactionSystem(object):
             if raise_on_unk:
                 for k in cont:
                     if k not in substance_keys:
-                        raise KeyError("Unkown substance key: %s" % k)
+                        raise KeyError("Unknown substance key: %s" % k)
             cont = [cont[k] for k in substance_keys]
         if unit is not None:
             cont = to_unitless(cont, unit)
@@ -790,7 +790,7 @@ class ReactionSystem(object):
 
         Notes
         -----
-        The function does not take into account wheter there actually exists a
+        The function does not take into account whether there actually exists a
         reaction path leading to a substance. Note also that the upper limit is
         per substance, i.e. the sum of all upper bounds amount to more substance than
         available in ``init_conc``.

--- a/chempy/tests/test_chemistry.py
+++ b/chempy/tests/test_chemistry.py
@@ -462,11 +462,11 @@ def test_balance_stoichiometry__very_underdetermined():
 
 @requires("sympy", "pulp")
 def test_balance_stoichiometry__underdetermined__canoncial():
-    # This tests for canoncial representation of the underdetermined system
+    # This tests for canonical representation of the underdetermined system
     # where all coefficients are integer and >= 1. It is however of limited
     # practical use (and hence marked ``xfail``) since underdetermined systems
     # have infinite number of solutions. It should however be possible to rewrite
-    # the logic so that such canoncial results are returned from balance_stoichiometry
+    # the logic so that such canonical results are returned from balance_stoichiometry
     r2 = {"O2", "O3", "C", "NO", "N2O", "NO2", "N2O4"}
     p2 = {"CO", "CO2", "N2"}
     bal2 = balance_stoichiometry(r2, p2, underdetermined=None)

--- a/chempy/units.py
+++ b/chempy/units.py
@@ -157,7 +157,7 @@ concentration = {"amount": 1} - volume
 
 
 def get_derived_unit(registry, key):
-    """Get the unit of a physcial quantity in a provided unit system.
+    """Get the unit of a physical quantity in a provided unit system.
 
     Parameters
     ----------
@@ -231,7 +231,7 @@ def _latex_from_dimensionality(dim):
 
 
 def latex_of_unit(quant):
-    """Returns LaTeX reperesentation of the unit of a quantity
+    """Returns LaTeX representation of the unit of a quantity
 
     Examples
     --------
@@ -243,7 +243,7 @@ def latex_of_unit(quant):
 
 
 def unicode_of_unit(quant):
-    """Returns unicode reperesentation of the unit of a quantity
+    """Returns unicode representation of the unit of a quantity
 
     Examples
     --------
@@ -255,7 +255,7 @@ def unicode_of_unit(quant):
 
 
 def html_of_unit(quant):
-    """Returns HTML reperesentation of the unit of a quantity
+    """Returns HTML representation of the unit of a quantity
 
     Examples
     --------
@@ -279,7 +279,7 @@ def unit_registry_from_human_readable(unit_registry):
             unit_quants = list(pq.Quantity(0, u_symbol).dimensionality.keys())
 
         if len(unit_quants) != 1:
-            raise TypeError("Unkown UnitQuantity: {}".format(unit_registry[k]))
+            raise TypeError("Unknown UnitQuantity: {}".format(unit_registry[k]))
         else:
             new_registry[k] = factor * unit_quants[0]
     return new_registry

--- a/chempy/util/_expr.py
+++ b/chempy/util/_expr.py
@@ -59,7 +59,7 @@ def _implicit_conversion(obj):
 
 
 class Expr(object):
-    """Baseclass for Expressions corresponding to physical quantitites.
+    """Baseclass for Expressions corresponding to physical quantities.
 
     The design assumes that a large group of different Expr subclasses may
     be evaluated with some shared state (parameter_keys). The backend kwarg

--- a/chempy/util/_expr_deprecated.py
+++ b/chempy/util/_expr_deprecated.py
@@ -30,7 +30,7 @@ def _mk_Poly(parameter_name, reciprocal=False, shift_name="shift"):
     Parameters
     ----------
     parameter: str
-        name of paramter
+        name of parameter
     reciprocal: bool
         whether the polynomial is in the reciprocal of the parameter
 

--- a/chempy/util/_julia.py
+++ b/chempy/util/_julia.py
@@ -64,7 +64,7 @@ def _r(r, p, substmap, parmap, *, unit_conc, unit_time, variables=None):
             parmap[pk], substmap[prod]
         )
     else:
-        raise NotImplementedError("Whats that?")
+        raise NotImplementedError("What's that?")
     return r_str, pk, abs(ratcoeff)
 
 

--- a/chempy/util/_quantities.py
+++ b/chempy/util/_quantities.py
@@ -15,7 +15,7 @@ def format_units_html(udict, font="%s", mult=r"&sdot;", paren=False):
 
     Exponentiation (m**2) will be replaced with superscripts (m<sup>2</sup>})
 
-    No formating is done, change `font` argument to e.g.:
+    No formatting is done, change `font` argument to e.g.:
     '<span style="color: #0000a0">%s</span>' to have text be colored blue.
 
     Multiplication (*) are replaced with the symbol specified by the mult

--- a/chempy/util/arithmeticdict.py
+++ b/chempy/util/arithmeticdict.py
@@ -23,11 +23,11 @@ def _itruediv(d1, d2):
 
 
 class ArithmeticDict(defaultdict):
-    """A dictionary which supports arithmetics
+    """A dictionary which supports arithmetic
 
     Subclassed from defaultdict, with support for addition, subtraction,
     multiplication and division. If other term/factor has a :meth:`keys` method
-    the arithmetics are performed on a key per key basis. If :meth:`keys` is
+    the arithmetic are performed on a key per key basis. If :meth:`keys` is
     missing, the operation is broadcasted onto all values.
     Nonexisting keys are interpreted to signal a zero.
 

--- a/chempy/util/graph.py
+++ b/chempy/util/graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Convenince functions for representing reaction systems as graphs.
+Convenience functions for representing reaction systems as graphs.
 """
 import os
 import subprocess
@@ -20,20 +20,20 @@ def rsys2dot(
 ):
     """
     Returns list of lines of DOT (graph description language)
-    formated graph.
+    formatted graph.
 
     Parameters
     ==========
     rsys: ReactionSystem
     tex: bool (default False)
-        If set True, output will be LaTeX formated
+        If set True, output will be LaTeX formatted
     (Substance need to have latex_name attribute set)
     rprefix: string
         Reaction enumeration prefix, default: r
     rref0: integer
-        Reaction enumeration inital counter value, default: 1
+        Reaction enumeration initial counter value, default: 1
     nodeparams: string
-        DOT formated param list, default: [label={} shape=diamond]
+        DOT formatted param list, default: [label={} shape=diamond]
 
     Returns
     =======

--- a/chempy/util/parsing.py
+++ b/chempy/util/parsing.py
@@ -447,7 +447,7 @@ def _parse_multiplicity(strings, substance_keys=None):
     if substance_keys is not None:
         for k in result:
             if k not in substance_keys:
-                raise ValueError("Unkown substance_key: %s" % k)
+                raise ValueError("Unknown substance_key: %s" % k)
     return result
 
 

--- a/chempy/util/regression.py
+++ b/chempy/util/regression.py
@@ -195,7 +195,7 @@ def least_squares(x, y, w=1):  # w == 1 => OLS, w != 1 => WLS
 
     References
     ----------
-    Wikipedia & standard texts on least sqaures method.
+    Wikipedia & standard texts on least squares method.
     Comment regarding R2 in WLS:
         Willett, John B., and Judith D. Singer. "Another cautionary note about R 2:
         Its use in weighted least-squares regression analysis."
@@ -280,7 +280,7 @@ irls.ones = lambda x, y, b, c: 1
 
 if np is not None:
     irls.exp = lambda x, y, b, c: np.exp(b[1] * x)
-    irls.gaussian = lambda x, y, b, c: np.exp(-((b[1] * x) ** 2))  # guassian weighting
+    irls.gaussian = lambda x, y, b, c: np.exp(-((b[1] * x) ** 2))  # gaussian weighting
     irls.abs_residuals = lambda x, y, b, c: np.abs(b[0] + b[1] * x - y)
 
 

--- a/chempy/util/table.py
+++ b/chempy/util/table.py
@@ -135,7 +135,7 @@ def rsys2tablines(
     coldelim : string
         column delimiter (default: ' & ')
     tex : bool
-        use latex formated output (default: True)
+        use latex formatted output (default: True)
     ref_fmt : string or callable
         format string of ``ref`` attribute of reactions
     unit_registry : unit registry

--- a/examples/Ammonia.ipynb
+++ b/examples/Ammonia.ipynb
@@ -51,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's define som e initial concentrations and governing equilibria:"
+    "Let's define some initial concentrations and governing equilibria:"
    ]
   },
   {
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In thise case they give essentially the same answer:"
+    "In this case they give essentially the same answer:"
    ]
   },
   {

--- a/examples/NaCl_precipitation.ipynb
+++ b/examples/NaCl_precipitation.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Multi-phase chemical equilibria: sodium chloride precipitation\n",
-    "In this notebook we will look at how ChemPy can formulate non-linear systems of equations based on precipitation. For more backgroud on the non-linear equation system you may want to look at the notebook \"conditional\" in the [pyneqsys repo](https://github.com/bjodah/pyneqsys)."
+    "In this notebook we will look at how ChemPy can formulate non-linear systems of equations based on precipitation. For more background on the non-linear equation system you may want to look at the notebook \"conditional\" in the [pyneqsys repo](https://github.com/bjodah/pyneqsys)."
    ]
   },
   {

--- a/examples/_carbon_dioxide.ipynb
+++ b/examples/_carbon_dioxide.ipynb
@@ -56,7 +56,7 @@
     "#eqsys = EqSystem(reactions, species)\n",
     "#eqsys\n",
     "\n",
-    "# Before this works, mass conservation equations must be adjusted to deal with an \"inifinte\" amount of gas:\n",
+    "# Before this works, mass conservation equations must be adjusted to deal with an \"infinite\" amount of gas:\n",
     "#eqsys.root(init_conc, state=298.15*u.K)"
    ]
   }

--- a/examples/_kinetics_demo.ipynb
+++ b/examples/_kinetics_demo.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Rate constants choosen rather arbitrarily for demonstration purposes\n",
+    "# Rate constants chosen rather arbitrarily for demonstration purposes\n",
     "system_str = \"\"\"\n",
     "  2 Fe+2 +  H2O2 -> 2 Fe+3     + 2 OH-        ; 42\n",
     "  2 Fe+3 +  H2O2 -> 2 Fe+2     +   O2  + 2 H+ ; 17\n",

--- a/examples/ammonical_cupric_solution.ipynb
+++ b/examples/ammonical_cupric_solution.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# System of non-linear equations - Coupled chemical equilibria\n",
-    "Author: Björn Dahlgren, Applied Physcial Chemistry, KTH Royal Insitiute of Technology\n",
+    "Author: Björn Dahlgren, Applied Physical Chemistry, KTH Royal Insitiute of Technology\n",
     "\n",
     "In this example we will study the equilibria between aqueous cupric ions and ammonia.\n",
     "We will use [ChemPy](https://github.com/bjodah/chempy) which is a Python package collecting functions and classes useful for chemistry related problems. We will also make use of SymPy for manipulating and inspecting the formulae encountered."
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let us define the equilibria, data are from course material at Applied Physcial Chemistry, KTH Royal Insitiute of Technology."
+    "Now, let us define the equilibria, data are from course material at Applied Physical Chemistry, KTH Royal Insitiute of Technology."
    ]
   },
   {
@@ -140,7 +140,7 @@
    "metadata": {},
    "source": [
     "To keep our numerical treatment as simple as possible we will try to avoid representing\n",
-    "$Cu(OH)_2(s)$ explicitly (which is present in the three last equilibria). This is becuase the\n",
+    "$Cu(OH)_2(s)$ explicitly (which is present in the three last equilibria). This is because the\n",
     "system of equations change when precipitation sets in.\n",
     "\n",
     "However, we do want to keep the two last equilibria, therefore we rewrite\n",
@@ -256,7 +256,7 @@
    "source": [
     "We could cast the preservation equations into [reduced row echelon form](https://en.wikipedia.org/wiki/Row_echelon_form) (which would remove one equation), but for now we'll leave this be and rely on the Levenberg-Marquardt algorithm to solve our problem in a least-squares sense. (Levenberg-Marquardt uses [QR-decomposition](https://en.wikipedia.org/wiki/QR_decomposition) internally for which it is acceptable to have overdetermined systems).\n",
     "\n",
-    "Let's solve the equations for our inital concentrations:"
+    "Let's solve the equations for our initial concentrations:"
    ]
   },
   {

--- a/examples/aqueous_radiolysis.ipynb
+++ b/examples/aqueous_radiolysis.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Aqueous radiolysis\n",
     "In this notebook we will look at the reactive species in water subjected to ionizing radiation.\n",
-    "The reaction-set is simply has been taken from the litterature and we will not pay to much attention\n",
+    "The reaction-set is simply has been taken from the literature and we will not pay to much attention\n",
     "to it, but rather focus on the analysis of dominant reactions toward the end."
    ]
   },

--- a/examples/bokeh_interactive.py
+++ b/examples/bokeh_interactive.py
@@ -1,6 +1,6 @@
 """
 Interactive kinetics app with sliders.
-Start by runing:
+Start by running:
     $ bokeh serve interactive.py
 Add --show argument or navigate to:
     http://localhost:5006/interactive

--- a/examples/bokeh_interactive_arrhenius.py
+++ b/examples/bokeh_interactive_arrhenius.py
@@ -1,6 +1,6 @@
 """
 Interactive kinetics app with sliders.
-Start by runing:
+Start by running:
     $ bokeh serve interactive.py
 Add --show argument or navigate to:
     http://localhost:5006/interactive

--- a/examples/bokeh_interactive_arrhenius_units.py
+++ b/examples/bokeh_interactive_arrhenius_units.py
@@ -1,6 +1,6 @@
 """
 Interactive kinetics app with sliders (with units).
-Start by runing:
+Start by running:
     $ bokeh serve interactive.py
 Add --show argument or navigate to:
     http://localhost:5006/interactive

--- a/examples/bokeh_interactive_robertson.py
+++ b/examples/bokeh_interactive_robertson.py
@@ -1,6 +1,6 @@
 """
 Interactive kinetics app with sliders.
-Start by runing:
+Start by running:
     $ bokeh serve interactive.py
 Add --show argument or navigate to:
     http://localhost:5006/interactive

--- a/examples/bokeh_interactive_units.py
+++ b/examples/bokeh_interactive_units.py
@@ -1,6 +1,6 @@
 """
 Interactive kinetics app with sliders (with units).
-Start by runing:
+Start by running:
     $ bokeh serve interactive.py
 Add --show argument or navigate to:
     http://localhost:5006/bokeh_interactive_units

--- a/examples/protein_binding_unfolding_4state_model.ipynb
+++ b/examples/protein_binding_unfolding_4state_model.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will model thermodynamic properties using enthalpy (H), entropy (S) and heat capacity (Cp). Kinetic paramaters (rate constants) are assumed to follow the Eyring equation:"
+    "We will model thermodynamic properties using enthalpy (H), entropy (S) and heat capacity (Cp). Kinetic parameters (rate constants) are assumed to follow the Eyring equation:"
    ]
   },
   {
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Numerical integration of ODE systems require a guess for the inital step-size. We can derive an upper bound for an \"Euler-forward step\" from initial concentrations and restrictions on mass-conservation:"
+    "Numerical integration of ODE systems require a guess for the initial step-size. We can derive an upper bound for an \"Euler-forward step\" from initial concentrations and restrictions on mass-conservation:"
    ]
   },
   {

--- a/index.ipynb
+++ b/index.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "<h1 style=\"text-align:center;\">Example notebooks for ChemPy</h1>\n",
     "\n",
-    "This is a collection of demonstration notebooks for chempy. The chempy package contains classes and functions for modelling e.g. chemical kinetics, chemical equilibria (e.g. speciation problems). It also collects a steadily growing collection of parametrizations of various chemical properties from the litterature.\n",
+    "This is a collection of demonstration notebooks for chempy. The chempy package contains classes and functions for modelling e.g. chemical kinetics, chemical equilibria (e.g. speciation problems). It also collects a steadily growing collection of parametrizations of various chemical properties from the literature.\n",
     "\n",
     "You can view these notebooks online with [Binder](https://mybinder.org/v2/gh/bjodah/chempy/f5f2546e79e165ba8fb258fc87d83a7fbdcbad64?filepath=index.ipynb). \n",
     "\n",

--- a/joss-paper/paper.md
+++ b/joss-paper/paper.md
@@ -51,8 +51,8 @@ numerically using pyodesys [@dahlgren_pyodesys_2018] and pyneqsys
 Thanks to the use of SymPy [@Meurer2017], stoichiometry problems with
 a single unique solution can be solved analytically, as well as
 under-determined systems, where the answer then contains a free parameter.
-The under-determined formulation can also be expressed in a canoncial form
-with coefficients minimzed using PuLP [@mitchell2011pulp;@lougee2003common].
+The under-determined formulation can also be expressed in a canonical form
+with coefficients minimized using PuLP [@mitchell2011pulp;@lougee2003common].
 In fact, most equations and parametrizations in ChemPy support---in addition to
 NumPy arrays [@vanderWalt2011]---also symbolic input, as well as arrays
 with explicit units. The latter allows ChemPy to check that, e.g., the correct

--- a/scripts/check_clean_repo_on_master.sh
+++ b/scripts/check_clean_repo_on_master.sh
@@ -4,6 +4,6 @@ if [[ $(git rev-parse --abbrev-ref HEAD) != master ]]; then
     exit 1
 fi
 if [[ ! -z $(git status -s) ]]; then
-    echo "'git status' show there are some untracked/uncommited changes. Aborting..."
+    echo "'git status' show there are some untracked/uncommitted changes. Aborting..."
     exit 1
 fi

--- a/scripts/dir_to_branch.sh
+++ b/scripts/dir_to_branch.sh
@@ -22,5 +22,5 @@ cd $WORKDIR
 cp -r ${UPLOAD_DIR}/. $OUTPUTDIR/
 cd $OUTPUTDIR
 git add -f . > /dev/null
-git commit -m "Lastest docs from successful drone build (hash: ${DRONE_COMMIT})"
+git commit -m "Latest docs from successful drone build (hash: ${DRONE_COMMIT})"
 #git push -f origin $OVERWRITE_UPLOAD_BRANCH

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if len(RELEASE_VERSION) > 0:
         TAGGED_RELEASE = True
         __version__ = RELEASE_VERSION[1:]
     else:
-        raise ValueError("Ill formated version")
+        raise ValueError("Ill formatted version")
 else:
     TAGGED_RELEASE = False
     # read __version__ attribute from _release.py:
@@ -93,7 +93,7 @@ classifiers = [
 with io.open(_path_under_setup(pkg_name, "__init__.py"), "rt", encoding="utf-8") as f:
     short_description = f.read().split('"""')[1].split("\n")[1]
 if not 10 < len(short_description) < 255:
-    warnings.warn("Short description from __init__.py proably not read correctly")
+    warnings.warn("Short description from __init__.py probably not read correctly")
 long_descr = io.open(_path_under_setup("README.rst"), encoding="utf-8").read()
 if not len(long_descr) > 100:
     warnings.warn("Long description from README.rst probably not read correctly.")


### PR DESCRIPTION
[`codespell --ignore-words-list="ans,claus,fith,nam,nd,serie,te" -w .`](https://pypi.org/project/codespell)