### PR TITLE
Add __hash__ method to Substance class

### DIFF
--- a/chempy/chemistry.py
+++ b/chempy/chemistry.py
@@ -98,6 +98,17 @@ class Substance(object):
                 return False
         return True
 
+    def __hash__(self) -> int:
+        return sum(
+            map(
+                hash,
+                (
+                    getattr(self, k)
+                    for k in self.attrs
+                ),
+            )
+        )
+
     @property
     def charge(self):
         """Convenience property for accessing ``composition[0]``"""


### PR DESCRIPTION
Allow substances to be used in dictionaries, sets etc. by including a __hash__ method in the class.